### PR TITLE
Revert "[AT-7797] Make compatible with ruby 3.4.4"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ config/config.yml
 .rspec_status
 
 .ruby-version
-
-.vscode

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
---format progress
+--format documentation
 --color
 --require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    legacy-trust-cayman-api (0.2.14)
+    legacy-trust-cayman-api (0.1.13)
       awrence
       oauth2
       plissken
@@ -9,70 +9,63 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    awrence (3.0.0)
-    base64 (0.3.0)
-    bigdecimal (3.2.2)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    awrence (2.0.1)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
     crack (1.0.0)
       bigdecimal
       rexml
-    diff-lcs (1.6.2)
-    faraday (2.13.2)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
-    hashdiff (1.2.0)
+    diff-lcs (1.5.1)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
+    hashdiff (1.1.0)
     hashie (5.0.0)
-    json (2.13.0)
-    jwt (3.1.2)
+    jwt (2.8.0)
       base64
-    logger (1.7.0)
-    method_source (1.1.0)
-    multi_xml (0.7.2)
-      bigdecimal (~> 3.1)
-    net-http (0.6.0)
+    method_source (1.0.0)
+    multi_xml (0.6.0)
+    net-http (0.4.1)
       uri
-    oauth2 (2.0.12)
-      faraday (>= 0.17.3, < 4.0)
-      jwt (>= 1.0, < 4.0)
-      logger (~> 1.2)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
-      version_gem (>= 1.1.8, < 3)
-    plissken (3.0.0)
-    pry (0.15.2)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    plissken (2.0.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (6.0.2)
-    rack (3.1.16)
-    rake (13.3.0)
-    rexml (3.4.1)
-    rspec (3.13.1)
+    public_suffix (5.0.4)
+    rack (3.0.9.1)
+    rake (13.1.0)
+    rexml (3.2.6)
+    rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.5)
+    rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.5)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.5)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.4)
-    snaky_hash (2.0.3)
-      hashie (>= 0.1.0, < 6)
-      version_gem (>= 1.1.8, < 3)
-    uri (1.0.3)
-    vcr (6.3.1)
-      base64
-    version_gem (1.1.8)
-    webmock (3.25.1)
+    rspec-support (3.13.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    uri (0.13.0)
+    vcr (6.2.0)
+    version_gem (1.1.3)
+    webmock (3.22.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -90,4 +83,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.7.0
+   2.5.6

--- a/lib/legacy_trust_cayman/version.rb
+++ b/lib/legacy_trust_cayman/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module LegacyTrustCayman
-  VERSION = '0.2.14'
+  VERSION = '0.2.13'
   API_VERSION = '1.0.0'
 end


### PR DESCRIPTION
Reverts BankToTheFuture/legacy-trust-cayman-api-ruby#5